### PR TITLE
Skip initialization: PrcessPhoenix and LeakCanary

### DIFF
--- a/superglue-app/build.gradle
+++ b/superglue-app/build.gradle
@@ -151,9 +151,9 @@ dependencies {
   compile 'com.jakewharton.byteunits:byteunits:0.9.1'
   compile 'com.jakewharton.rxbinding:rxbinding:1.0.1'
   compile 'com.jakewharton.threetenabp:threetenabp:1.0.5'
+  compile 'com.jakewharton:process-phoenix:2.0.0'
   internalDebugCompile 'com.jakewharton.madge:madge:1.1.4'
   internalDebugCompile 'com.jakewharton.scalpel:scalpel:1.1.2'
-  internalDebugCompile 'com.jakewharton:process-phoenix:2.0.0'
 
   internalCompile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
   productionCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'

--- a/superglue-app/src/main/java/superglue/SuperGlueApp.java
+++ b/superglue-app/src/main/java/superglue/SuperGlueApp.java
@@ -2,6 +2,7 @@ package superglue;
 
 import android.app.Application;
 import android.support.annotation.NonNull;
+import com.jakewharton.processphoenix.ProcessPhoenix;
 import com.jakewharton.threetenabp.AndroidThreeTen;
 import superglue.data.Injector;
 import superglue.data.LumberYard;
@@ -19,8 +20,11 @@ public class SuperGlueApp extends Application {
 
   @Override public void onCreate() {
     super.onCreate();
-    AndroidThreeTen.init(this);
+    if (LeakCanary.isInAnalyzerProcess(this) || ProcessPhoenix.isPhoenixProcess(this)) {
+      return;
+    }
     LeakCanary.install(this);
+    AndroidThreeTen.init(this);
 
     component = DaggerInitializer.init(this);
     component.inject(this);


### PR DESCRIPTION
If either of these processes are run there is no need to run
initialization for the rest of the application.

Fixes #2